### PR TITLE
ENH: Add cxx composite build action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,154 @@
+name: 'Build, test, package'
+description: 'Build, test, and package distributions for an ITK external module.'
+inputs:
+  cmake-build-type:
+    required: false
+    default: 'MinSizeRel'
+  cmake-options:
+    description: 'Additional CMake arguments to use in building and testing the current remote module.'
+    required: false
+    default: ''
+  itk-cmake-options:
+    description: 'Additional CMake arguments to use in building ITK, such as enabling certain remote modules.'
+    required: false
+    default: ''
+  itk-git-tag:
+    required: false
+    default: '835dc01388d22c4b4c9a46b01dbdfe394ec23511' # v5.3rc04.post2
+
+runs:
+  using: "composite"
+  steps:
+    - name: Define OS-dependent environment variables
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        echo "C_COMPILER=cl.exe" >> $GITHUB_ENV       # defines env.C_COMPILER
+        echo "CXX_COMPILER=cl.exe" >> $GITHUB_ENV     # defines env.CXX_COMPILER
+        echo "Set env.C_COMPILER=${{ env.C_COMPILER}} and env.CXX_COMPILER=${{ env.CXX_COMPILER }}"
+
+    - name: Define OS-dependent environment variables
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        echo "C_COMPILER=clang" >> $GITHUB_ENV
+        echo "CXX_COMPILER=clang++" >> $GITHUB_ENV
+        echo "Set env.C_COMPILER=${{ env.C_COMPILER}} and env.CXX_COMPILER=${{ env.CXX_COMPILER }}"
+
+    - name: Define OS-dependent environment variables
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "C_COMPILER=gcc" >> $GITHUB_ENV
+        echo "CXX_COMPILER=g++" >> $GITHUB_ENV
+        echo "Set env.C_COMPILER=${{ env.C_COMPILER}} and env.CXX_COMPILER=${{ env.CXX_COMPILER }}"
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install build dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ninja
+        python -m pip install cookiecutter
+
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
+
+    - name: Download ITK
+      shell: bash
+      run: |
+        cd ..
+        git clone https://github.com/InsightSoftwareConsortium/ITK.git
+        cd ITK
+        git checkout ${{ inputs.itk-git-tag }}
+        pwd
+
+    - name: Build ITK
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        cd ..
+        mkdir ITK-build
+        cd ITK-build
+        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ env.C_COMPILER }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ env.CXX_COMPILER }}" -DCMAKE_BUILD_TYPE:STRING=${{ inputs.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF ${{ inputs.itk-cmake-options }} -GNinja ../ITK
+        ninja
+
+    - name: Build ITK
+      if: runner.os == 'Windows'
+      shell: cmd
+      run: |
+        cd ..
+        mkdir ITK-build
+        cd ITK-build
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        cmake -DCMAKE_C_COMPILER:FILEPATH="${{ env.C_COMPILER }}" -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER="${{ env.CXX_COMPILER }}" -DCMAKE_BUILD_TYPE:STRING=${{ inputs.cmake-build-type }} -DBUILD_TESTING:BOOL=OFF ${{ inputs.itk-cmake-options }} -GNinja ../ITK
+        ninja
+
+    - name: Fetch CTest driver script
+      shell: bash
+      run: |
+        curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
+
+    - name: Configure CTest script
+      shell: bash
+      run: |
+        operating_system="${{ runner.os }}_${{ env.RUNNER_ARCH }}"
+        echo "CTest dashboard root is at ${{ env.GITHUB_WORKSPACE }}/.."
+        cat > dashboard.cmake << EOF
+        set(CTEST_SITE "GitHubActions")
+        file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/.." CTEST_DASHBOARD_ROOT)
+        file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/" CTEST_SOURCE_DIRECTORY)
+        file(TO_CMAKE_PATH "\$ENV{GITHUB_WORKSPACE}/../build" CTEST_BINARY_DIRECTORY)
+        set(dashboard_source_name "${GITHUB_REPOSITORY}")
+        if(ENV{GITHUB_REF} MATCHES "master")
+          set(branch "-master")
+          set(dashboard_model "Continuous")
+        else()
+          set(branch "-${GITHUB_REF}")
+          set(dashboard_model "Experimental")
+        endif()
+        set(CTEST_BUILD_NAME "${GITHUB_REPOSITORY}-${operating_system}-\${branch}")
+        set(CTEST_UPDATE_VERSION_ONLY 1)
+        set(CTEST_TEST_ARGS \${CTEST_TEST_ARGS} PARALLEL_LEVEL \${PARALLEL_LEVEL})
+        set(CTEST_BUILD_CONFIGURATION "Release")
+        set(CTEST_CMAKE_GENERATOR "Ninja")
+        set(CTEST_CUSTOM_WARNING_EXCEPTION
+          \${CTEST_CUSTOM_WARNING_EXCEPTION}
+          # macOS Azure VM Warning
+          "ld: warning: text-based stub file"
+          )
+        set(dashboard_no_clean 1)
+        set(ENV{CC} ${{ env.C_COMPILER }})
+        set(ENV{CXX} ${{ env.CXX_COMPILER }})
+        if(WIN32)
+          set(ENV{PATH} "\${CTEST_DASHBOARD_ROOT}/ITK-build/bin;\$ENV{PATH}")
+        endif()
+        set(dashboard_cache "
+        ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
+        Module_SplitComponents_BUILD_EXAMPLES:BOOL=ON
+        BUILD_TESTING:BOOL=ON
+        ${{ inputs.cmake-options }}
+        ")
+        string(TIMESTAMP build_date "%Y-%m-%d")
+        message("CDash Build Identifier: \${build_date} \${CTEST_BUILD_NAME}")
+        message("CTEST_SITE = \${CTEST_SITE}")
+        include(\${CTEST_SCRIPT_DIRECTORY}/itk_common.cmake)
+        EOF
+        cat dashboard.cmake
+
+    - name: Build and test
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        ctest --output-on-failure -j 2 -V -S dashboard.cmake
+
+    - name: Build and test
+      if: runner.os == 'Windows'
+      shell: cmd
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        ctest --output-on-failure -j 2 -V -S dashboard.cmake


### PR DESCRIPTION
Partially ports ITK module template `build-test-package.yml` Github Action specification as a composite action that can be referenced by other projects in relation to [https://github.com/InsightSoftwareConsortium/ITKModuleTemplate/issues/131](https://github.com/InsightSoftwareConsortium/ITKModuleTemplate/issues/131).

Notes:
- This is a first pass and will be tagged as a prerelease. Documentation indicates that the composite action cannot be tested in isolation, ~it may be necessary to pull this into `main` first and then test with a remote module development branch. [https://docs.github.com/en/actions/creating-actions/creating-a-composite-action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action)~
- A composite action runs in sequence and cannot run multiple jobs. As such this composite action only aims to address cxx building and testing. A separate repo and .yml file will be required for Python build/test/packaging.

EDIT: I am able to reference the development branch commit hash for testing in [https://github.com/InsightSoftwareConsortium/ITKSplitComponents/pull/60](https://github.com/InsightSoftwareConsortium/ITKSplitComponents/pull/60)