### PR TITLE
ENH: Add parameter to set cxx test options

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -6,6 +6,9 @@ on:
       cmake-options:
         required: false
         type: string
+      ctest-options:
+        required: false
+        type: string
       itk-cmake-options:
         required: false
         type: string
@@ -130,11 +133,11 @@ jobs:
     - name: Build and test
       if: matrix.os != 'windows-2019'
       run: |
-        ctest --output-on-failure -j 2 -V -S dashboard.cmake
+        ctest --output-on-failure -j 2 -V -S dashboard.cmake ${{ inputs.ctest-options }}
 
     - name: Build and test
       if: matrix.os == 'windows-2019'
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        ctest --output-on-failure -j 2 -V -S dashboard.cmake
+        ctest --output-on-failure -j 2 -V -S dashboard.cmake ${{ inputs.ctest-options }}
       shell: cmd


### PR DESCRIPTION
Allows remote module projects to pass ctest options such as excluding invalid tests by name with `-E <test_name>`.

Caveats:
- Several ctest options are already set by the workflow, such as the dashboard to receive results, the number of jobs to run, and verbosity.
- Only available for cxx workflow.

Closes #5. Verified in https://github.com/InsightSoftwareConsortium/ITKElastix/pull/173 .