### PR TITLE
ENH: Bump `gh-action-pypi-publish` to v1.5.1

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -172,7 +172,7 @@ jobs:
 
     - name: Publish 🐍 Python 📦 package to PyPI
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@v1.5.1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
`gh-action-pypi-publish@master` warns that the `master` branch is not receiving updates. This change sets a fixed, stable release to use instead.

Generalizes fix from https://github.com/InsightSoftwareConsortium/ITKCLEsperanto/pull/49/files to reusable workflow.