### PR TITLE
ENH: Versions as strings, not numbers, so that 3.1 != 3.10, etc.

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.8"
 
     - name: Install build dependencies
       run: |

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -15,13 +15,13 @@ on:
       pypi_password:
         required: false  # Packages will not be uploaded to PyPI if not set
 
-jobs:  
+jobs:
   build-linux-python-packages:
     runs-on: ubuntu-20.04
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [37, 38, 39, 310]
+        python-version: ["37", "38", "39", "310"]
 
     steps:
     - uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
         else
           CMAKE_OPTIONS="--cmake_options ${{ inputs.cmake-options }}"
         fi
-          
+
         for tarball in "-manylinux_2_28" "-manylinux2014"; do
           rm -rf ITKPythonPackage
           export TARBALL_SPECIALIZATION=${tarball}
@@ -105,7 +105,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: [7, 8, 9, 10]
+        python-version-minor: ["7", "8", "9", "10"]
 
     steps:
     - name: Get specific version of CMake, Ninja

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.8"
 
     - name: Install build dependencies
       shell: bash


### PR DESCRIPTION
Write versions as strings rather than numbers because 3.1 != 3.10, etc.  Nothing is broken at present but in the future as, e.g., the Python version for some things goes from 3.8 to 3.9 to 3.10, this could end up being an unexpected problem.