### PR TITLE
ENH: Introduce manylinux option with ARM

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -41,7 +41,7 @@ on:
 
 jobs:
 
-  build-linux-python-packages:
+  build-linux-py:
     runs-on: ubuntu-22.04
     strategy:
       max-parallel: 2
@@ -199,7 +199,7 @@ jobs:
 
   publish-python-packages-to-pypi:
     needs:
-      - build-linux-python-packages
+      - build-linux-py
       - build-macos-python-packages
       - build-windows-python-packages
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -31,21 +31,23 @@ on:
         required: false
         type: string
       manylinux-platforms:
-        description: 'colon-delimited list of "<manylinux-image>-<arch>" specializations'
+        description: 'JSON-formatted array of "<manylinux-image>-<arch>" specializations'
         required: false
         type: string
-        default: "_2_28-x64:2014-x64:_2_28-aarch64"
+        default: '["_2_28-x64","2014-x64","_2_28-aarch64"]'
     secrets:
       pypi_password:
         required: false  # Packages will not be uploaded to PyPI if not set
 
 jobs:
+
   build-linux-python-packages:
     runs-on: ubuntu-22.04
     strategy:
       max-parallel: 2
       matrix:
         python-version: ["37", "38", "39", "310", "311"]
+        manylinux-platform: ${{ fromJSON(inputs.manylinux-platforms) }}
 
     steps:
     - uses: actions/checkout@v3
@@ -81,14 +83,13 @@ jobs:
           CMAKE_OPTIONS="--cmake_options ${{ inputs.cmake-options }}"
         fi
 
-        MANYLINUX_PLATFORMS=${{ inputs.manylinux-platforms }}
-        for manylinux_version in ${MANYLINUX_PLATFORMS//:/ }; do
-          rm -rf ITKPythonPackage
-          export MANYLINUX_VERSION=`(echo ${manylinux_version} | cut -d '-' -f 1)`
-          export TARGET_ARCH=`(echo ${manylinux_version} | cut -d '-' -f 2)`
-          echo "Building for manylinux specialization ${MANYLINUX_VERSION} and target architecture ${TARGET_ARCH}"
-          ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }} $CMAKE_OPTIONS
-        done
+        MANYLINUX_PLATFORM=${{ matrix.manylinux-platform }}
+        echo "Manylinux platform ${MANYLINUX_PLATFORM}"
+        rm -rf ITKPythonPackage
+        export MANYLINUX_VERSION=`(echo ${MANYLINUX_PLATFORM} | cut -d '-' -f 1)`
+        export TARGET_ARCH=`(echo ${MANYLINUX_PLATFORM} | cut -d '-' -f 2)`
+        echo "Building for manylinux specialization ${MANYLINUX_VERSION} and target architecture ${TARGET_ARCH}"
+        ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }} $CMAKE_OPTIONS
 
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -19,7 +19,7 @@ on:
         description: 'Git tag or commit hash for ITKPythonPackage build scripts to use'
         required: false
         type: string
-        default: 'aa3b0767801ecc489f6219777ead2652f7ac4ccf'
+        default: 'cc3cbd2edd350d193536d78c5f8ee5ace1e6defd'
       itk-python-package-org:
         description: 'Github organization name for fetching ITKPythonPackage build scripts'
         required: false
@@ -30,6 +30,11 @@ on:
         # example: InsightSoftwareConsortium/ITKMeshToPolyData@3ad8f08:InsightSoftwareConsortium/ITKBSplineGradient@0.3.0
         required: false
         type: string
+      manylinux-platforms:
+        description: 'colon-delimited list of "<manylinux-image>-<arch>" specializations'
+        required: false
+        type: string
+        default: "_2_28-x64:2014-x64:_2_28-aarch64"
     secrets:
       pypi_password:
         required: false  # Packages will not be uploaded to PyPI if not set
@@ -76,10 +81,12 @@ jobs:
           CMAKE_OPTIONS="--cmake_options ${{ inputs.cmake-options }}"
         fi
 
-        for manylinux_version in "_2_28" "2014"; do
+        MANYLINUX_PLATFORMS=${{ inputs.manylinux-platforms }}
+        for manylinux_version in ${MANYLINUX_PLATFORMS//:/ }; do
           rm -rf ITKPythonPackage
-          export MANYLINUX_VERSION=${manylinux_version}
-          echo "Building for manylinux specialization ${MANYLINUX_VERSION}"
+          export MANYLINUX_VERSION=`(echo ${manylinux_version} | cut -d '-' -f 1)`
+          export TARGET_ARCH=`(echo ${manylinux_version} | cut -d '-' -f 2)`
+          echo "Building for manylinux specialization ${MANYLINUX_VERSION} and target architecture ${TARGET_ARCH}"
           ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }} $CMAKE_OPTIONS
         done
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,23 @@ to direct workflow execution.
     itk-module-deps: 'InsightSoftwareConsortium/ITKMeshToPolyData@3ad8f08:InsightSoftwareConsortium/ITKBSplineGradient@0.3.0'
 ```
 
+- `manylinux-platforms`: List of [manylinux](https://github.com/pypa/manylinux)
+    specialization build targets for Linux Python module wheels. Manylinux "provides
+    a convenient way to distribute binary Python extensions as wheels on Linux";
+    see the [manylinux README](https://github.com/pypa/manylinux#manylinux) for more details.
+    A list entry includes both the name of the manylinux specialization, which is
+    related to the toolset to be used, and the platform architecture to target.
+    All supported specialization and architecture pairs are enabled by default
+    and listed in the example below, but can be disabled by removing them from the
+    input list in the calling external module workflow.
+    The list is colon-delimited and wheels will be built in the order provided.
+    The list is formatted as "<specialization>-<target_arch>:<specialization>-<target_arch>".
+
+```yaml
+  with:
+    manylinux-platforms: '_2_28-aarch64:_2_28-x64:2014-x64'
+```
+
 ## Contributing
 
 Community contributions to `ITKRemoteModuleBuildTestPackageAction` are welcome!

--- a/README.md
+++ b/README.md
@@ -282,21 +282,22 @@ to direct workflow execution.
     itk-module-deps: 'InsightSoftwareConsortium/ITKMeshToPolyData@3ad8f08:InsightSoftwareConsortium/ITKBSplineGradient@0.3.0'
 ```
 
-- `manylinux-platforms`: List of [manylinux](https://github.com/pypa/manylinux)
+- `manylinux-platforms`: Array of [manylinux](https://github.com/pypa/manylinux)
     specialization build targets for Linux Python module wheels. Manylinux "provides
     a convenient way to distribute binary Python extensions as wheels on Linux";
     see the [manylinux README](https://github.com/pypa/manylinux#manylinux) for more details.
-    A list entry includes both the name of the manylinux specialization, which is
+    An array entry includes both the name of the manylinux specialization, which is
     related to the toolset to be used, and the platform architecture to target.
     All supported specialization and architecture pairs are enabled by default
     and listed in the example below, but can be disabled by removing them from the
-    input list in the calling external module workflow.
-    The list is colon-delimited and wheels will be built in the order provided.
-    The list is formatted as "<specialization>-<target_arch>:<specialization>-<target_arch>".
+    input array in the calling external module workflow.
+    The array follows [JavaScript Object Notation (JSON)](https://www.json.org/json-en.html) syntax
+    and GHA jobs will launch in the order provided.
+    The array is formatted as '["<specialization>-<target_arch>","<specialization>-<target_arch>"]'.
 
 ```yaml
   with:
-    manylinux-platforms: '_2_28-aarch64:_2_28-x64:2014-x64'
+    manylinux-platforms: '["_2_28-x64","2014-x64","_2_28-aarch64"]'
 ```
 
 ## Contributing


### PR DESCRIPTION
Exposes input parameter to allow the user to build for multiple Linux
toolsets and target architectures via available manylinux docker images.

Depends on ARM support introduced in ITKPythonPackage:
https://github.com/InsightSoftwareConsortium/ITKPythonPackage/pull/236