### PR TITLE
ENH: Fix `Node.js` warnings linked to GitHub actions

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -52,10 +52,10 @@ jobs:
             cmake-build-type: "MinSizeRel"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.8"
 

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -43,7 +43,7 @@ jobs:
         python-version: ["37", "38", "39", "310", "311"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: 'Free up disk space'
       run: |
@@ -99,7 +99,7 @@ jobs:
       max-parallel: 2
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: 'Specific XCode version'
       run: |


### PR DESCRIPTION
Fix `Node.js` warnings linked to GitHub actions: transition to `actions/checkout@v3`, and `actions/setup-python@v4`.

Fixes:
```
Node.js 12 actions are deprecated. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16:
actions/checkout@v2, actions/setup-python@v2, lukka/get-cmake@v3.22.2
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKIOMeshSTL/actions/runs/3791396544