### PR TITLE
ENH: Update to Python 3.9 in `build-test-cxx` workflow

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -54,10 +54,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.9"
 
     - name: Install build dependencies
       run: |


### PR DESCRIPTION
For consistency with ITK C++ continuous integration workflow.

See https://github.com/InsightSoftwareConsortium/ITK/blob/master/Testing/ContinuousIntegration/AzurePipelinesLinux.yml#L29

Closes #4