### PR TITLE
ENH: Fix `Node.js` warnings linked to CMake GitHub actions

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -65,7 +65,7 @@ jobs:
         python -m pip install ninja
 
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.22.2
+      uses: lukka/get-cmake@v3.24.2
 
     - name: Download ITK
       run: |

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -102,7 +102,7 @@ jobs:
         sudo xcode-select -s "/Applications/Xcode_13.2.1.app"
 
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.22.2
+      uses: lukka/get-cmake@v3.24.2
 
     - name: 'Fetch build script'
       run: |
@@ -143,7 +143,7 @@ jobs:
 
     steps:
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.22.2
+      uses: lukka/get-cmake@v3.24.2
 
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Fix `Node.js` warnings linked to CMake GitHub actions: transition to `lukka/get-cmake@v3.24.2`.

Fixes:
```
Node.js 12 actions are deprecated. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16:
lukka/get-cmake@v3.22.2
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKBSplineGradient/actions/runs/3824095979

Cross-referencing
https://github.com/lukka/get-cmake/issues/46#issuecomment-1283449995

Left behind in commit 73e57e9.