### PR TITLE
ENH: Fix Node.js warnings linked to artifact download GitHub actions

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -198,7 +198,7 @@ jobs:
 
     steps:
     - name: Download Python Packages
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
 
     - name: Prepare packages for upload
       run: |


### PR DESCRIPTION
Fix `Node.js` warnings linked to artifact download GitHub actions: transition to `actions/download-artifact@v3`.

Fixes:
```
python-build-workflow / publish-python-packages-to-pypi
Node.js 12 actions are deprecated. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: actions/download-artifact@v2
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKTextureFeatures/actions/runs/3832886629

Cross-referencing
https://github.com/actions/download-artifact/pull/134

Left behind in commit 6e81bbd.