### PR TITLE
ENH: Add Python Jupyter Notebook testing procedure

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -35,6 +35,11 @@ on:
         required: false
         type: string
         default: '["_2_28-x64","2014-x64","_2_28-aarch64"]'
+      test-notebooks:
+        description: 'Option to test Jupyter Notebooks in examples/ directory with applied changes'
+        required: false
+        type: boolean
+        default: false
     secrets:
       pypi_password:
         required: false  # Packages will not be uploaded to PyPI if not set
@@ -196,6 +201,50 @@ jobs:
       with:
         name: WindowsWheel3.${{ matrix.python-version-minor }}
         path: dist/*.whl
+
+  test-linux-notebooks:
+    if: inputs.test-notebooks
+    needs:
+      - build-linux-py
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install build dependencies
+        shell: bash
+        run: |
+          if [[ -f requirements.txt ]]; then
+            python -m pip install -r requirements.txt
+          elif [[ -f ./binder/requirements.txt ]]; then
+            python -m pip install -r ./binder/requirements.txt
+          fi
+          python -m pip install pytest nbmake
+
+      - name: Download Python Package Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: LinuxWheel310
+
+      - name: Install Python Package Artifact
+        run: |
+          ls .
+          wheel_name_full=`(find . -name "*cp310-manylinux_2_28_x86_64.whl")`
+          echo "wheel_name_full ${wheel_name_full}"
+          # extract wheel name which may be an abbreviation of the module name
+          # ex. ./itk_splitcomponents-cp310..._64.whl -> itk-splitcomponents
+          wheel_name_prefix=`(echo ${wheel_name_full} | cut -d'-' -f1 | cut -d'/' -f2 | sed -e 's/_/-/g')`
+          echo "wheel_name_prefix ${wheel_name_prefix}"
+          python -m pip uninstall ${wheel_name_prefix} -y
+          python -m pip install ${wheel_name_full}
+
+      - name: Test notebooks
+        run: |
+          pytest --nbmake --nbmake-timeout=30000 examples/*.ipynb
 
   publish-python-packages-to-pypi:
     needs:

--- a/README.md
+++ b/README.md
@@ -300,6 +300,18 @@ to direct workflow execution.
     manylinux-platforms: '["_2_28-x64","2014-x64","_2_28-aarch64"]'
 ```
 
+- `test-notebooks`: Boolean option to test Jupyter Notebook examples located in the
+    `examples/` directory of the external module. A `requirements.txt` file
+    should be provided in either the external module root or `binder/` directories
+    to indicate notebook prerequisites for testing. Default value is `false`, notebook
+    tests may be enabled for a repository containing notebook examples by setting
+    the value to `true`.
+
+```yaml
+  with:
+    test-notebooks: true
+```
+
 ## Contributing
 
 Community contributions to `ITKRemoteModuleBuildTestPackageAction` are welcome!


### PR DESCRIPTION
Adds job to `build-test-package-python` workflow that retrieves a built Linux Python wheel artifact previously output by the workflow and uses it to test Jupyter Notebooks in the `examples/` folder of the external module.

For initial implementation only Linux wheels are tested with the Python version fixed at 3.10. To coincide with the Github Actions Linux runner image and machine architecture, only the `_2_28-x64` wheel is used.

Depends on #17. Tested in https://github.com/tbirdso/ITKSplitComponents/actions/runs/3843342651. Closes https://github.com/InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/issues/49 .

EDIT: Note that the ITKSplitComponents test job [fails](https://github.com/tbirdso/ITKSplitComponents/actions/runs/3843342651/jobs/6546347627) because the ITKSplitComponents example notebook needs to be updated (current kernel is python2). What is important is that the newly built package is correctly installed and the notebook test runs, which is confirmed by looking back through the logs.
