### PR TITLE
ENH: Validate wheel build output

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -96,6 +96,28 @@ jobs:
         echo "Building for manylinux specialization ${MANYLINUX_VERSION} and target architecture ${TARGET_ARCH}"
         ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }} $CMAKE_OPTIONS
 
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - name: Validate build output
+      shell: bash
+      run: |
+        python -m pip install twine
+        ls dist/
+
+        MANYLINUX_PLATFORM=${{ matrix.manylinux-platform }}
+        MANYLINUX_VERSION=`(echo ${MANYLINUX_PLATFORM} | cut -d '-' -f 1)`
+        TARGET_ARCH_NAME=`(echo ${MANYLINUX_PLATFORM} | cut -d '-' -f 2)`
+        if [[ ${TARGET_ARCH_NAME} == "x64" ]]; then
+          TARGET_ARCH_NAME="x86_64" # Match auditwheel naming convention
+        fi
+        WHEEL_PATTERN="dist/itk_*cp${{ matrix.python-version }}*manylinux${MANYLINUX_VERSION}*${TARGET_ARCH_NAME}.whl"
+
+        echo "Searching for wheels matching pattern ${WHEEL_PATTERN}"
+        python -m twine check ${WHEEL_PATTERN}
+
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v3
       with:
@@ -140,6 +162,28 @@ jobs:
           CMAKE_OPTIONS="--cmake_options ${{ inputs.cmake-options }}"
         fi
         ./macpython-download-cache-and-build-module-wheels.sh $CMAKE_OPTIONS
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - name: Validate build output
+      shell: bash
+      run: |
+        python -m pip install twine
+        ls dist/
+
+        WHEEL_PATTERN="dist/itk_*macosx*.whl"
+        EXPECTED_WHEEL_COUNT=5
+
+        WHEEL_COUNT=`(ls ${WHEEL_PATTERN} | wc -l)`
+        if (( ${WHEEL_COUNT} != ${EXPECTED_WHEEL_COUNT} )); then
+          echo "Expected ${EXPECTED_WHEEL_COUNT} wheels but found ${WHEEL_COUNT}"
+          exit 1
+        fi
+
+        python -m twine check ${WHEEL_PATTERN}
 
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v3
@@ -195,6 +239,22 @@ jobs:
 
         mkdir -p '${{ github.workspace }}\dist'
         cp 'dist\*.whl' '${{ github.workspace }}\dist'
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - name: Validate build output
+      shell: bash
+      run: |
+        python -m pip install twine
+        ls dist/
+
+        WHEEL_PATTERN="dist/itk_*cp3${{ matrix.python-version-minor }}*win*.whl"
+        echo "Searching for wheels matching pattern ${WHEEL_PATTERN}"
+
+        python -m twine check ${WHEEL_PATTERN}
 
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Adds step to validate that wheels are built successfully across platforms. Tailored to match granularity of build processes on each runner platform:
- Each Linux job expects one wheel output and verifies Python version, toolset, target platform, target architecture;
- Each Windows job expects one wheel output and verifies Python version, target platform;
- Each macOS job expects one wheel output per Python version (currently 3.7-3.11) and verifies target platform and wheel count

Addresses https://github.com/InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/issues/38

Tested at https://github.com/tbirdso/ITKSplitComponents/actions/runs/3931853870/jobs/6723658106