### PR TITLE
BUG: Match XCode version for ITK build

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -66,6 +66,11 @@ jobs:
 
     - name: Get specific version of CMake, Ninja
       uses: lukka/get-cmake@v3.24.2
+      
+    - name: 'Specific XCode version'
+      if: matrix.os == 'macos-12'
+      run: |
+        sudo xcode-select -s "/Applications/Xcode_13.2.1.app"
 
     - name: Download ITK
       run: |


### PR DESCRIPTION
Use specific XCode version 13.2 that is used in building ITK Python packages.

Tested at https://github.com/InsightSoftwareConsortium/ITKSplitComponents/actions/runs/3969955914/jobs/6805099767