### PR TITLE
ENH: Expose input parameter for Python versions

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -30,6 +30,11 @@ on:
         # example: InsightSoftwareConsortium/ITKMeshToPolyData@3ad8f08:InsightSoftwareConsortium/ITKBSplineGradient@0.3.0
         required: false
         type: string
+      python3-minor-versions:
+        description: 'JSON-formatted array of Python 3.x minor version wheel targets'
+        required: false
+        type: string
+        default: '["7","8","9","10","11"]'
       manylinux-platforms:
         description: 'JSON-formatted array of "<manylinux-image>-<arch>" specializations'
         required: false
@@ -51,7 +56,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: ["37", "38", "39", "310", "311"]
+        python3-minor-version: ${{ fromJSON(inputs.python3-minor-versions) }}
         manylinux-platform: ${{ fromJSON(inputs.manylinux-platforms) }}
 
     steps:
@@ -94,9 +99,10 @@ jobs:
         export MANYLINUX_VERSION=`(echo ${MANYLINUX_PLATFORM} | cut -d '-' -f 1)`
         export TARGET_ARCH=`(echo ${MANYLINUX_PLATFORM} | cut -d '-' -f 2)`
         echo "Building for manylinux specialization ${MANYLINUX_VERSION} and target architecture ${TARGET_ARCH}"
-        ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }} $CMAKE_OPTIONS
 
-    - name: Set up Python 3.10
+        ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp3${{ matrix.python3-minor-version }} $CMAKE_OPTIONS
+
+    - name: Set up Python 3.10 for Validation
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
@@ -113,7 +119,7 @@ jobs:
         if [[ ${TARGET_ARCH_NAME} == "x64" ]]; then
           TARGET_ARCH_NAME="x86_64" # Match auditwheel naming convention
         fi
-        WHEEL_PATTERN="dist/itk_*cp${{ matrix.python-version }}*manylinux${MANYLINUX_VERSION}*${TARGET_ARCH_NAME}.whl"
+        WHEEL_PATTERN="dist/itk_*cp3${{ matrix.python3-minor-version }}*manylinux${MANYLINUX_VERSION}*${TARGET_ARCH_NAME}.whl"
 
         echo "Searching for wheels matching pattern ${WHEEL_PATTERN}"
         python -m twine check ${WHEEL_PATTERN}
@@ -121,7 +127,7 @@ jobs:
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: LinuxWheel${{ matrix.python-version }}
+        name: LinuxWheel3${{ matrix.python3-minor-version }}
         path: dist/*.whl
 
   build-macos-py:
@@ -129,7 +135,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python3-minor-version: ${{ fromJSON(inputs.python3-minor-versions) }}
 
     steps:
     - uses: actions/checkout@v3
@@ -163,9 +169,9 @@ jobs:
         else
           CMAKE_OPTIONS="--cmake_options ${{ inputs.cmake-options }}"
         fi
-        ./macpython-download-cache-and-build-module-wheels.sh $CMAKE_OPTIONS "${{ matrix.python-version }}"
+        ./macpython-download-cache-and-build-module-wheels.sh $CMAKE_OPTIONS "3.${{ matrix.python3-minor-version }}"
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.10 for Validation
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
@@ -190,7 +196,7 @@ jobs:
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: MacOSWheels
+        name: MacOSWheel3${{ matrix.python3-minor-version }}
         path: dist/*.whl
 
   build-windows-python-packages:
@@ -198,7 +204,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: ["7", "8", "9", "10", "11"]
+        python3-minor-version: ${{ fromJSON(inputs.python3-minor-versions) }}
 
     steps:
     - name: Get specific version of CMake, Ninja
@@ -237,23 +243,24 @@ jobs:
         $env:ITKPYTHONPACKAGE_TAG = "${{ inputs.itk-python-package-tag }}"
         $env:ITKPYTHONPACKAGE_ORG = "${{ inputs.itk-python-package-org }}"
         $env:ITK_MODULE_PREQ = "${{ inputs.itk-module-deps }}"
-        ./windows-download-cache-and-build-module-wheels.ps1 "${{ matrix.python-version-minor }}" -cmake_options "${{ inputs.cmake-options }}"
+
+        ./windows-download-cache-and-build-module-wheels.ps1 "${{ matrix.python3-minor-version }}" -cmake_options "${{ inputs.cmake-options }}"
 
         mkdir -p '${{ github.workspace }}\dist'
         cp 'dist\*.whl' '${{ github.workspace }}\dist'
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.10 for Validation
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
 
     - name: Validate build output
-      shell: bash
+      shell: pwsh
       run: |
         python -m pip install twine
         ls dist/
 
-        WHEEL_PATTERN="dist/itk_*cp3${{ matrix.python-version-minor }}*win*.whl"
+        $WHEEL_PATTERN = "dist/itk_*cp3${{ matrix.python3-minor-version }}*win*.whl"
         echo "Searching for wheels matching pattern ${WHEEL_PATTERN}"
 
         python -m twine check ${WHEEL_PATTERN}
@@ -261,7 +268,7 @@ jobs:
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: WindowsWheel3.${{ matrix.python-version-minor }}
+        name: WindowsWheel3${{ matrix.python3-minor-version }}
         path: dist/*.whl
 
   test-linux-notebooks:
@@ -275,7 +282,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: "3.${{ fromJSON(inputs.python3-minor-versions)[0] }}"
 
       - name: Install build dependencies
         shell: bash
@@ -290,12 +297,12 @@ jobs:
       - name: Download Python Package Artifacts
         uses: actions/download-artifact@v3
         with:
-          name: LinuxWheel310
+          name: LinuxWheel3${{ fromJSON(inputs.python3-minor-versions)[0] }}
 
       - name: Install Python Package Artifact
         run: |
           ls .
-          wheel_name_full=`(find . -name "*cp310-manylinux_2_28_x86_64.whl")`
+          wheel_name_full=`(find . -name "*cp3${{ fromJSON(inputs.python3-minor-versions)[0] }}*-manylinux_2_28_x86_64.whl")`
           echo "wheel_name_full ${wheel_name_full}"
           # extract wheel name which may be an abbreviation of the module name
           # ex. ./itk_splitcomponents-cp310..._64.whl -> itk-splitcomponents

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -19,7 +19,7 @@ on:
         description: 'Git tag or commit hash for ITKPythonPackage build scripts to use'
         required: false
         type: string
-        default: 'ee05fd4fa5feedc32afbed32b84b9c9eb0518036'
+        default: 'dc6a18600233ac69a8f42b7489e4edf6a5d8883a'
       itk-python-package-org:
         description: 'Github organization name for fetching ITKPythonPackage build scripts'
         required: false

--- a/README.md
+++ b/README.md
@@ -283,6 +283,18 @@ to direct workflow execution.
     itk-module-deps: 'InsightSoftwareConsortium/ITKMeshToPolyData@3ad8f08:InsightSoftwareConsortium/ITKBSplineGradient@0.3.0'
 ```
 
+- `python3-minor-versions`: Array of Python 3.x wheel minor versions to target for building.
+    The array follows [JavaScript Object Notation (JSON)](https://www.json.org/json-en.html) syntax
+    and GHA jobs will launch in the order provided. One wheel is built per Python version and
+    target platform. The first listed Python version may also be used for running Linux notebook tests
+    if enabled. The default value is a list of [currently supported Python versions](https://devguide.python.org/versions/)
+    ascending from oldest to newest.
+
+```yaml
+  with:
+    python3-minor-versions: '["7","8","9","10","11"]` # Builds for Python 3.7 through 3.11
+```
+
 - `manylinux-platforms`: Array of [manylinux](https://github.com/pypa/manylinux)
     specialization build targets for Linux Python module wheels. Manylinux "provides
     a convenient way to distribute binary Python extensions as wheels on Linux";
@@ -304,7 +316,9 @@ to direct workflow execution.
 - `test-notebooks`: Boolean option to test Jupyter Notebook examples located in the
     `examples/` directory of the external module. A `requirements.txt` file
     should be provided in either the external module root or `binder/` directories
-    to indicate notebook prerequisites for testing. Default value is `false`, notebook
+    to indicate notebook prerequisites for testing. The first Python version listed in
+    `python3-minor-versions` will be used, i.e. if "9" is listed first then notebook
+    tests will be run with Python 3.9. Default value is `false`, notebook
     tests may be enabled for a repository containing notebook examples by setting
     the value to `true`.
 


### PR DESCRIPTION
Allows the user to specify `python3-minor-versions` to set Python 3.x targets for module wheel packaging. Python versions 3.7 through 3.11 are set as default according to Python maintenance schedule.

Notebook tests are also updated to test the x64 module wheel corresponding to the first specified Python version. Under previous behavior 3.10 packages were always selected for testing as it was assumed that 3.7 through 3.11 packages were always built. Updated behavior adapts to user requested versions.

https://devguide.python.org/versions/

Tests:

Defaults: https://github.com/tbirdso/ITKSplitComponents/actions/runs/4992038821

Request a single Python version: https://github.com/tbirdso/ITKSplitComponents/actions/runs/4992038821

Request a version subset, reordered so that a different version is used in notebook testing: https://github.com/tbirdso/ITKSplitComponents/actions/runs/4992048825/jobs/8939596188

Note that passing an empty list of versions fails to run: https://github.com/tbirdso/ITKSplitComponents/actions/runs/4992061867

Closes #62 