### PR TITLE
COMP: Do not change location when launching VS development shell

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -109,7 +109,7 @@ jobs:
       run: |
         Set-PSDebug -Trace 1
         cd ..
-        & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64
+        & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64 -SkipAutomaticLocation
         mkdir ITK-build
         cd ITK-build
 
@@ -192,5 +192,5 @@ jobs:
       if: matrix.os == 'windows-2022'
       shell: pwsh
       run: |
-        & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64
+        & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64 -SkipAutomaticLocation
         ctest --output-on-failure -j 2 -V -S dashboard.cmake ${{ inputs.ctest-options }}

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -236,7 +236,7 @@ jobs:
         if (Test-Path dist) { rm dist -r -fo }
 
         cd ../../im
-        & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64
+        & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64 -SkipAutomaticLocation
         $env:CC="cl.exe"
         $env:CXX="cl.exe"
         $env:ITK_PACKAGE_VERSION = "${{ inputs.itk-wheel-tag }}"


### PR DESCRIPTION
RTK's GH actions were failing, see [here](https://github.com/RTKConsortium/RTK/actions/runs/5388515011). This patch seems to solve the issue, see [here](https://github.com/RTKConsortium/RTK/actions/runs/5443090881). I had encountered a similar issue before in Cuda GH actions ([here](https://github.com/RTKConsortium/RTK/blob/master/.github/workflows/build-test-cxx-cuda.yml#L81) and [here](https://github.com/RTKConsortium/RTK/blob/master/.github/workflows/build-test-package-python-cuda.yml#L101)), I don't know what triggers different behaviors...