### PR TITLE
ENH: Update notebook requirements search paths

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -287,7 +287,9 @@ jobs:
       - name: Install build dependencies
         shell: bash
         run: |
-          if [[ -f requirements.txt ]]; then
+          if [[ -f ./examples/requirements.txt ]]; then
+            python -m pip install -r ./examples/requirements.txt
+          elif [[ -f requirements.txt ]]; then
             python -m pip install -r requirements.txt
           elif [[ -f ./binder/requirements.txt ]]; then
             python -m pip install -r ./binder/requirements.txt


### PR DESCRIPTION
Prioritize `requirements.txt` file living alongside example notebooks for notebook testing.

Supports resolution for https://github.com/InsightSoftwareConsortium/ITKElastix/issues/262