### PR TITLE
ENH: Drop Python 3.7 from minor version list

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -34,7 +34,7 @@ on:
         description: 'JSON-formatted array of Python 3.x minor version wheel targets'
         required: false
         type: string
-        default: '["7","8","9","10","11"]'
+        default: '["8","9","10","11"]'
       manylinux-platforms:
         description: 'JSON-formatted array of "<manylinux-image>-<arch>" specializations'
         required: false


### PR DESCRIPTION
Drop Python 3.7 from minor version list: Python 3.7 reached its EOL on 2023-06-27.