### PR TITLE
ENH: Update build-test-cxx.yml to latest ITK SHA

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -23,7 +23,7 @@ on:
         description: 'Git version tag or commit hash for the base ITK build'
         required: false
         type: string
-        default: 'v5.3.0'
+        default: '444acec2c4d615882e5700a141cd6f37febe5797'
       itk-module-deps:
         description: 'Colon-delimited list of ITK remote module dependencies to build. Format as module_name@tag:...'
         # example: MeshToPolyData@3ad8f08:BSplineGradient@0.3.0


### PR DESCRIPTION
This gives us changes from PRs: https://github.com/InsightSoftwareConsortium/ITK/pull/4404 and https://github.com/InsightSoftwareConsortium/ITK/pull/4412 (among other things).