### PR TITLE
ENH: Update build-test-cxx.yml to avoid clang warning in a remote module

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -23,7 +23,7 @@ on:
         description: 'Git version tag or commit hash for the base ITK build'
         required: false
         type: string
-        default: '444acec2c4d615882e5700a141cd6f37febe5797'
+        default: '9e8f6a473d6313eac2e6adef0d108badeeb58a46'
       itk-module-deps:
         description: 'Colon-delimited list of ITK remote module dependencies to build. Format as module_name@tag:...'
         # example: MeshToPolyData@3ad8f08:BSplineGradient@0.3.0


### PR DESCRIPTION
This depends on https://github.com/InsightSoftwareConsortium/ITK/pull/4425.