### PR TITLE
ENH: Put each Windows CMake option between quotes

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -313,7 +313,12 @@ jobs:
         $env:ITKPYTHONPACKAGE_ORG = "${{ inputs.itk-python-package-org }}"
         $env:ITK_MODULE_PREQ = "${{ inputs.itk-module-deps }}"
 
-        ./windows-download-cache-and-build-module-wheels.ps1 "${{ matrix.python3-minor-version }}" -cmake_options "${{ inputs.cmake-options }}"
+        # Put each (space separated) option in CMAKE_OPTIONS between quotes
+        $CMAKE_OPTIONS = "${{ inputs.cmake-options }}" -Replace ' ', '" "'
+        if("$cmake_options".length -gt 0) {
+          $CMAKE_OPTIONS = """${CMAKE_OPTIONS}"""
+        }
+        ./windows-download-cache-and-build-module-wheels.ps1 "${{ matrix.python3-minor-version }}" -cmake_options "${CMAKE_OPTIONS}"
 
         mkdir -p '${{ github.workspace }}\dist'
         cp 'dist\*.whl' '${{ github.workspace }}\dist'


### PR DESCRIPTION
This change is required since InsightSoftwareConsortium/ITKPythonPackage@12af8e3b5be219e859266d28cc324d29af6489af

Without this change, the windows compilation was [failing](https://github.com/RTKConsortium/RTK/actions/runs/9383434085/job/25837037344#step:6:263). It is [successful](https://github.com/RTKConsortium/RTK/actions/runs/9384976262/job/25841997234#step:6:268) with it.