### PR TITLE
COMP: Avoid windows-2022 20240603.1.1 updates

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -36,13 +36,13 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
+        os: [ubuntu-22.04, windows-2019, macos-12, macos-14]
         include:
           - os: ubuntu-22.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "MinSizeRel"
-          - os: windows-2022
+          - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
             cmake-build-type: "Release"
@@ -95,7 +95,7 @@ jobs:
         git checkout ${{ inputs.itk-git-tag }}
 
     - name: Build ITK
-      if: matrix.os != 'windows-2022'
+      if: matrix.os != 'windows-2019'
       shell: bash
       run: |
         cd ..
@@ -119,12 +119,12 @@ jobs:
         ninja
 
     - name: Build ITK
-      if: matrix.os == 'windows-2022'
+      if: matrix.os == 'windows-2019'
       shell: pwsh
       run: |
         Set-PSDebug -Trace 1
-        cd ..
-        & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64 -SkipAutomaticLocation
+        & "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\Launch-VsDevShell.ps1"
+        cd ${{ github.workspace }}/..
         mkdir ITK-build
         cd ITK-build
 
@@ -199,13 +199,14 @@ jobs:
         cat dashboard.cmake
 
     - name: Build and test
-      if: matrix.os != 'windows-2022'
+      if: matrix.os != 'windows-2019'
       run: |
         ctest --output-on-failure -j 2 -V -S dashboard.cmake ${{ inputs.ctest-options }}
 
     - name: Build and test
-      if: matrix.os == 'windows-2022'
+      if: matrix.os == 'windows-2019'
       shell: pwsh
       run: |
-        & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64 -SkipAutomaticLocation
+        & "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\Launch-VsDevShell.ps1"
+        cd ${{ github.workspace }}
         ctest --output-on-failure -j 2 -V -S dashboard.cmake ${{ inputs.ctest-options }}


### PR DESCRIPTION
Changes in this update:

  https://github.com/actions/runner-images/commit/a615999e85d5b3f3853c691cd59fcfe89f0495ae#diff-d3119a278ce9ce80fc4b5af63a1112fb3a044aec3e6002d838e8eb26d7a3a499

Seem to cause segfault in test execution.