### PR TITLE
Revert "COMP: Avoid windows-2022 20240603.1.1 updates"

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -36,13 +36,13 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-22.04, windows-2019, macos-12, macos-14]
+        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
         include:
           - os: ubuntu-22.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "MinSizeRel"
-          - os: windows-2019
+          - os: windows-2022
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
             cmake-build-type: "Release"
@@ -95,7 +95,7 @@ jobs:
         git checkout ${{ inputs.itk-git-tag }}
 
     - name: Build ITK
-      if: matrix.os != 'windows-2019'
+      if: matrix.os != 'windows-2022'
       shell: bash
       run: |
         cd ..
@@ -119,12 +119,12 @@ jobs:
         ninja
 
     - name: Build ITK
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       shell: pwsh
       run: |
         Set-PSDebug -Trace 1
-        & "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\Launch-VsDevShell.ps1"
-        cd ${{ github.workspace }}/..
+        cd ..
+        & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64 -SkipAutomaticLocation
         mkdir ITK-build
         cd ITK-build
 
@@ -199,14 +199,13 @@ jobs:
         cat dashboard.cmake
 
     - name: Build and test
-      if: matrix.os != 'windows-2019'
+      if: matrix.os != 'windows-2022'
       run: |
         ctest --output-on-failure -j 2 -V -S dashboard.cmake ${{ inputs.ctest-options }}
 
     - name: Build and test
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       shell: pwsh
       run: |
-        & "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\Launch-VsDevShell.ps1"
-        cd ${{ github.workspace }}
+        & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1" -Arch amd64 -SkipAutomaticLocation
         ctest --output-on-failure -j 2 -V -S dashboard.cmake ${{ inputs.ctest-options }}


### PR DESCRIPTION
This reverts commit 17e317843a6b0f953da17e8db8a56916acce3c97.

Reportedly resolved per @N-Dekker:

  https://github.com/SuperElastix/elastix/pull/1151