### PR TITLE
ENH: Bump CMake and checkout GitHub actions versions

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -75,7 +75,7 @@ jobs:
         python -m pip install ninja
 
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.24.2
+      uses: lukka/get-cmake@v3.29.0
 
     - name: 'Specific XCode version'
       if: matrix.os == 'macos-12'

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -135,7 +135,7 @@ jobs:
         python3-minor-version: ${{ fromJSON(inputs.python3-minor-versions) }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: 'Specific XCode version'
       run: |


### PR DESCRIPTION
Bump CMake and checkout GitHub actions versions.

Fixes:
```
cxx-build-workflow / build-test-cxx (ubuntu-22.04)
The following actions uses Node.js version which is deprecated and will be forced to run on node20:
lukka/get-cmake@v3.24.2.
For more info:
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

and
```
python-build-workflow / build-macos-py (8)
The following actions uses Node.js version which is deprecated and will be forced to run on node20:
actions/checkout@v3.
For more info:
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKAnalyzeObjectMap/actions/runs/10012233814