### PR TITLE
COMP: Use GNU tar and extract only relevant files

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
         # v5.4.0 + fixes
-        default: 'a52d9b596b4f0da5ddb770ee99851e5c65ca3053'
+        default: 'ca1a7e5809dd9dbc1ac3486ff601b5eb1b58184b'
       itk-python-package-org:
         description: 'Github organization name for fetching ITKPythonPackage build scripts'
         required: false


### PR DESCRIPTION
Fixes the following error:

./macpython-download-cache-and-build-module-wheels.sh: line 81: /Users/svc-dashboard/D/P/ITKPythonPackage/scripts/macpython-install-python.sh: No such file or directory Building module wheels
./macpython-download-cache-and-build-module-wheels.sh: line 85: /Users/svc-dashboard/D/P/ITKPythonPackage/scripts/macpython-build-module-wheels.sh: No such file or directory