### PR TITLE
ENH: Use macos-13 now to avoid disruption when macos-12 is retired

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
+        os: [ubuntu-22.04, windows-2022, macos-13, macos-14]
         include:
           - os: ubuntu-22.04
             c-compiler: "gcc"
@@ -46,7 +46,7 @@ jobs:
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
             cmake-build-type: "Release"
-          - os: macos-12
+          - os: macos-13
             c-compiler: "clang"
             cxx-compiler: "clang++"
             cmake-build-type: "MinSizeRel"
@@ -78,9 +78,9 @@ jobs:
       uses: lukka/get-cmake@v3.24.2
 
     - name: 'Specific XCode version'
-      if: matrix.os == 'macos-12'
+      if: matrix.os == 'macos-13'
       run: |
-        sudo xcode-select -s "/Applications/Xcode_13.2.1.app"
+        sudo xcode-select -s "/Applications/Xcode_14.3.1.app"
 
     - name: 'Specific XCode version'
       if: matrix.os == 'macos-14'


### PR DESCRIPTION
The macOS 12 runner image will be removed by December 3rd, 2024. To raise awareness of the upcoming removal, jobs using macOS 12 will temporarily fail during scheduled time periods defined below:

November 4, 9:00 AM - 7:00 PM EST
November 11, 9:00 AM - 7:00 PM EST
November 18, 9:00 AM - 7:00 PM EST
November 25, 9:00 AM - 7:00 PM EST

What you need to do

Jobs using the macos-12 YAML workflow label should be updated to macos-15, macos-14, macos-13, or macos-latest. You can always get up-to-date information on our tools by reading about the software in the runner images repository. Please contact GitHub Support if you run into any problems or need help.

(cherry picked from commit ed0534498647851b0ef330d25a94b939e9fe3743)