### PR TITLE
COMP: Update C++ builds to use latest release-5.4 branch

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -23,7 +23,8 @@ on:
         description: 'Git version tag or commit hash for the base ITK build'
         required: false
         type: string
-        default: 'v5.4.0'
+        # v5.4.0 + additional patches on the release-5.4 branch
+        default: '49413c3a9e8ecf0f912534e7c13f4c7bc3799d60'
       itk-module-deps:
         description: 'Colon-delimited list of ITK remote module dependencies to build. Format as module_name@tag:...'
         # example: MeshToPolyData@3ad8f08:BSplineGradient@0.3.0


### PR DESCRIPTION
Incorporates libtiff symbol conflicts addressed in https://github.com/InsightSoftwareConsortium/ITK/pull/4958 which has started to cause issues on Windows builds.