### PR TITLE
BUG: Disable Intel Mac Python package builds

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -131,74 +131,74 @@ jobs:
         name: LinuxWheel3${{ matrix.python3-minor-version }}${{ matrix.manylinux-platform }}
         path: dist/*.whl
 
-  build-macos-py:
-    runs-on: macos-12
-    strategy:
-      max-parallel: 2
-      matrix:
-        python3-minor-version: ${{ fromJSON(inputs.python3-minor-versions) }}
+  #build-macos-py:
+    #runs-on: macos-12
+    #strategy:
+      #max-parallel: 2
+      #matrix:
+        #python3-minor-version: ${{ fromJSON(inputs.python3-minor-versions) }}
 
-    steps:
-    - uses: actions/checkout@v3
+    #steps:
+    #- uses: actions/checkout@v3
 
-    - name: 'Specific XCode version'
-      run: |
-        sudo xcode-select -s "/Applications/Xcode_13.2.1.app"
+    #- name: 'Specific XCode version'
+      #run: |
+        #sudo xcode-select -s "/Applications/Xcode_13.2.1.app"
 
-    - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.29.0
+    #- name: Get specific version of CMake, Ninja
+      #uses: lukka/get-cmake@v3.29.0
 
-    - name: 'Fetch build script'
-      run: |
-        IPP_DOWNLOAD_GIT_TAG=${{ inputs.itk-python-package-tag }}
-        IPP_DOWNLOAD_ORG=${{ inputs.itk-python-package-org }}
-        curl -L https://raw.githubusercontent.com/${IPP_DOWNLOAD_ORG:=InsightSoftwareConsortium}/ITKPythonPackage/${IPP_DOWNLOAD_GIT_TAG:=master}/scripts/macpython-download-cache-and-build-module-wheels.sh -O
-        chmod u+x macpython-download-cache-and-build-module-wheels.sh
+    #- name: 'Fetch build script'
+      #run: |
+        #IPP_DOWNLOAD_GIT_TAG=${{ inputs.itk-python-package-tag }}
+        #IPP_DOWNLOAD_ORG=${{ inputs.itk-python-package-org }}
+        #curl -L https://raw.githubusercontent.com/${IPP_DOWNLOAD_ORG:=InsightSoftwareConsortium}/ITKPythonPackage/${IPP_DOWNLOAD_GIT_TAG:=master}/scripts/macpython-download-cache-and-build-module-wheels.sh -O
+        #chmod u+x macpython-download-cache-and-build-module-wheels.sh
 
-    - name: 'Build 🐍 Python 📦 package'
-      shell: bash
-      run: |
-        rm -rf dist
+    #- name: 'Build 🐍 Python 📦 package'
+      #shell: bash
+      #run: |
+        #rm -rf dist
 
-        export ITK_PACKAGE_VERSION=${{ inputs.itk-wheel-tag }}
-        export ITKPYTHONPACKAGE_TAG=${{ inputs.itk-python-package-tag }}
-        export ITKPYTHONPACKAGE_ORG=${{ inputs.itk-python-package-org }}
-        export ITK_MODULE_PREQ=${{ inputs.itk-module-deps }}
-        export MACOSX_DEPLOYMENT_TARGET=10.9
-        if [ -z ${{ inputs.cmake-options }} ]; then
-          CMAKE_OPTIONS=""
-        else
-          CMAKE_OPTIONS="--cmake_options ${{ inputs.cmake-options }}"
-        fi
-        ./macpython-download-cache-and-build-module-wheels.sh $CMAKE_OPTIONS "3.${{ matrix.python3-minor-version }}"
+        #export ITK_PACKAGE_VERSION=${{ inputs.itk-wheel-tag }}
+        #export ITKPYTHONPACKAGE_TAG=${{ inputs.itk-python-package-tag }}
+        #export ITKPYTHONPACKAGE_ORG=${{ inputs.itk-python-package-org }}
+        #export ITK_MODULE_PREQ=${{ inputs.itk-module-deps }}
+        #export MACOSX_DEPLOYMENT_TARGET=10.9
+        #if [ -z ${{ inputs.cmake-options }} ]; then
+          #CMAKE_OPTIONS=""
+        #else
+          #CMAKE_OPTIONS="--cmake_options ${{ inputs.cmake-options }}"
+        #fi
+        #./macpython-download-cache-and-build-module-wheels.sh $CMAKE_OPTIONS "3.${{ matrix.python3-minor-version }}"
 
-    - name: Set up Python 3.11 for Validation
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
+    #- name: Set up Python 3.11 for Validation
+      #uses: actions/setup-python@v5
+      #with:
+        #python-version: "3.11"
 
-    - name: Validate build output
-      shell: bash
-      run: |
-        python -m pip install twine
-        ls dist/
+    #- name: Validate build output
+      #shell: bash
+      #run: |
+        #python -m pip install twine
+        #ls dist/
 
-        WHEEL_PATTERN="dist/itk_*macosx*.whl"
-        EXPECTED_WHEEL_COUNT=1
+        #WHEEL_PATTERN="dist/itk_*macosx*.whl"
+        #EXPECTED_WHEEL_COUNT=1
 
-        WHEEL_COUNT=`(ls ${WHEEL_PATTERN} | wc -l)`
-        if (( ${WHEEL_COUNT} != ${EXPECTED_WHEEL_COUNT} )); then
-          echo "Expected ${EXPECTED_WHEEL_COUNT} wheels but found ${WHEEL_COUNT}"
-          exit 1
-        fi
+        #WHEEL_COUNT=`(ls ${WHEEL_PATTERN} | wc -l)`
+        #if (( ${WHEEL_COUNT} != ${EXPECTED_WHEEL_COUNT} )); then
+          #echo "Expected ${EXPECTED_WHEEL_COUNT} wheels but found ${WHEEL_COUNT}"
+          #exit 1
+        #fi
 
-        python -m twine check ${WHEEL_PATTERN}
+        #python -m twine check ${WHEEL_PATTERN}
 
-    - name: Publish Python package as GitHub Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: MacOSWheel3${{ matrix.python3-minor-version }}
-        path: dist/*.whl
+    #- name: Publish Python package as GitHub Artifact
+      #uses: actions/upload-artifact@v4
+      #with:
+        #name: MacOSWheel3${{ matrix.python3-minor-version }}
+        #path: dist/*.whl
 
   build-macos-arm-py:
     runs-on: macos-14
@@ -399,9 +399,9 @@ jobs:
   publish-python-packages-to-pypi:
     needs:
       - build-linux-py
-      - build-macos-py
       - build-macos-arm-py
       - build-windows-python-packages
+      #- build-macos-py
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
macos-12 GitHub Runner images are no longer available in GitHub Actions.

With ITK 5.4.1, we will build packages compatible with the macos-13 images.