### PR TITLE
ENH: Update Python packages to build against ITK 5.4.2

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -289,7 +289,7 @@ jobs:
     if: inputs.test-notebooks
     needs:
       - build-linux-py
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -132,7 +132,7 @@ jobs:
         path: dist/*.whl
 
   build-macos-py:
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       max-parallel: 2
       matrix:

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -131,79 +131,6 @@ jobs:
         name: LinuxWheel3${{ matrix.python3-minor-version }}${{ matrix.manylinux-platform }}
         path: dist/*.whl
 
-  build-macos-py:
-    runs-on: macos-13
-    strategy:
-      max-parallel: 2
-      matrix:
-        python3-minor-version: ${{ fromJSON(inputs.python3-minor-versions) }}
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: 'Specific XCode version'
-      run: |
-        sudo xcode-select -s "/Applications/Xcode_15.2.0.app"
-
-    - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.29.0
-
-    - name: 'Fetch build script'
-      run: |
-        IPP_DOWNLOAD_GIT_TAG=${{ inputs.itk-python-package-tag }}
-        IPP_DOWNLOAD_ORG=${{ inputs.itk-python-package-org }}
-        curl -L https://raw.githubusercontent.com/${IPP_DOWNLOAD_ORG:=InsightSoftwareConsortium}/ITKPythonPackage/${IPP_DOWNLOAD_GIT_TAG:=master}/scripts/macpython-download-cache-and-build-module-wheels.sh -O
-        chmod u+x macpython-download-cache-and-build-module-wheels.sh
-
-    - name: 'Build 🐍 Python 📦 package'
-      shell: bash
-      run: |
-        rm -rf dist
-
-        export ITK_PACKAGE_VERSION=${{ inputs.itk-wheel-tag }}
-        export ITKPYTHONPACKAGE_TAG=${{ inputs.itk-python-package-tag }}
-        export ITKPYTHONPACKAGE_ORG=${{ inputs.itk-python-package-org }}
-        export ITK_MODULE_PREQ=${{ inputs.itk-module-deps }}
-        if [ -z ${{ inputs.macosx-deployment-target }} ]; then
-          export MACOSX_DEPLOYMENT_TARGET=10.9
-        else
-          export MACOSX_DEPLOYMENT_TARGET=${{ inputs.macosx-deployment-target }}
-        fi
-        if [ -z ${{ inputs.cmake-options }} ]; then
-          CMAKE_OPTIONS=""
-        else
-          CMAKE_OPTIONS="--cmake_options ${{ inputs.cmake-options }}"
-        fi
-        ./macpython-download-cache-and-build-module-wheels.sh $CMAKE_OPTIONS "3.${{ matrix.python3-minor-version }}"
-
-    - name: Set up Python 3.11 for Validation
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
-
-    - name: Validate build output
-      shell: bash
-      run: |
-        python -m pip install twine
-        ls dist/
-
-        WHEEL_PATTERN="dist/itk_*macosx*.whl"
-        EXPECTED_WHEEL_COUNT=1
-
-        WHEEL_COUNT=`(ls ${WHEEL_PATTERN} | wc -l)`
-        if (( ${WHEEL_COUNT} != ${EXPECTED_WHEEL_COUNT} )); then
-          echo "Expected ${EXPECTED_WHEEL_COUNT} wheels but found ${WHEEL_COUNT}"
-          exit 1
-        fi
-
-        python -m twine check ${WHEEL_PATTERN}
-
-    - name: Publish Python package as GitHub Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: MacOSWheel3${{ matrix.python3-minor-version }}
-        path: dist/*.whl
-
   build-macos-arm-py:
     runs-on: macos-14
     strategy:
@@ -407,7 +334,6 @@ jobs:
   publish-python-packages-to-pypi:
     needs:
       - build-linux-py
-      - build-macos-py
       - build-macos-arm-py
       - build-windows-python-packages
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -34,7 +34,7 @@ on:
         description: 'JSON-formatted array of Python 3.x minor version wheel targets'
         required: false
         type: string
-        default: '["8","9","10","11"]'
+        default: '["9","10","11"]'
       manylinux-platforms:
         description: 'JSON-formatted array of "<manylinux-image>-<arch>" specializations'
         required: false

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -13,14 +13,13 @@ on:
         description: 'Github release version tag for the ITKPythonBuilds build archive to use'
         required: false
         type: string
-        default: 'v5.4.0'
+        default: 'v5.4.2.post1'
       itk-python-package-tag:
         # See https://github.com/InsightSoftwareConsortium/ITKPythonPackage
         description: 'Git tag or commit hash for ITKPythonPackage build scripts to use'
         required: false
         type: string
-        # v5.4.0 + fixes
-        default: 'ca1a7e5809dd9dbc1ac3486ff601b5eb1b58184b'
+        default: 'v5.4.2.post1'
       itk-python-package-org:
         description: 'Github organization name for fetching ITKPythonPackage build scripts'
         required: false

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -143,7 +143,7 @@ jobs:
 
     - name: 'Specific XCode version'
       run: |
-        sudo xcode-select -s "/Applications/Xcode_13.2.1.app"
+        sudo xcode-select -s "/Applications/Xcode_15.2.0.app"
 
     - name: Get specific version of CMake, Ninja
       uses: lukka/get-cmake@v3.29.0


### PR DESCRIPTION
Note: Fixes were required for the `itk` `5.4.2` package, which were
published to PyPI and GitHub Releases as `5.4.2.post1`.
