### PR TITLE
ENH: Mirror dockcross images to GHCR for reliable Python wheel builds

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -84,6 +84,38 @@ jobs:
         large-packages: "false"  # Takes too long to remove apt-get packages
         mandb:          "true"  # Speeds up future apt-get installs (disables man page generation), this CI does not use apt-get
 
+    - name: 'Pre-pull dockcross image'
+      run: |
+        MANYLINUX_PLATFORM=${{ matrix.manylinux-platform }}
+        MANYLINUX_VERSION=$(echo ${MANYLINUX_PLATFORM} | cut -d '-' -f 1)
+        TARGET_ARCH=$(echo ${MANYLINUX_PLATFORM} | cut -d '-' -f 2)
+        if [[ ${MANYLINUX_VERSION} == _2_28 && ${TARGET_ARCH} == x64 ]]; then
+          IMAGE_TAG="20240304-9e57d2b"
+        elif [[ ${MANYLINUX_VERSION} == 2014 ]]; then
+          IMAGE_TAG="20240304-9e57d2b"
+        else
+          echo "Unknown manylinux platform ${MANYLINUX_PLATFORM}, skipping pre-pull"
+          exit 0
+        fi
+        IMAGE="dockcross/manylinux${MANYLINUX_VERSION}-${TARGET_ARCH}:${IMAGE_TAG}"
+        GHCR_IMAGE="ghcr.io/insightsoftwareconsortium/dockcross-manylinux${MANYLINUX_VERSION}-${TARGET_ARCH}:${IMAGE_TAG}"
+        echo "Pre-pulling ${GHCR_IMAGE} (mirror of docker.io/${IMAGE})"
+        for attempt in 1 2 3; do
+          if docker pull "${GHCR_IMAGE}" 2>/dev/null; then
+            docker tag "${GHCR_IMAGE}" "docker.io/${IMAGE}"
+            echo "Successfully pulled from GHCR mirror"
+            exit 0
+          fi
+          echo "GHCR pull attempt ${attempt} failed, trying Docker Hub..."
+          if docker pull "docker.io/${IMAGE}"; then
+            echo "Successfully pulled from Docker Hub"
+            exit 0
+          fi
+          echo "Docker Hub pull attempt ${attempt} failed, retrying in 15s..."
+          sleep 15
+        done
+        echo "WARNING: All pull attempts failed, build script will retry"
+
     - name: 'Fetch build script'
       run: |
         IPP_DOWNLOAD_GIT_TAG=${{ inputs.itk-python-package-tag }}
@@ -179,6 +211,28 @@ jobs:
         android:        "false" # Takes too long
         large-packages: "false"  # Takes too long to remove apt-get packages
         mandb:          "true"  # Speeds up future apt-get installs (disables man page generation), this CI does not use apt-get
+
+    - name: 'Pre-pull manylinux aarch64 image'
+      run: |
+        IMAGE_TAG="2024-03-25-9206bd9"
+        IMAGE="quay.io/pypa/manylinux_2_28_aarch64:${IMAGE_TAG}"
+        GHCR_IMAGE="ghcr.io/insightsoftwareconsortium/dockcross-manylinux_2_28-aarch64:${IMAGE_TAG}"
+        echo "Pre-pulling ${GHCR_IMAGE} (mirror of ${IMAGE})"
+        for attempt in 1 2 3; do
+          if docker pull "${GHCR_IMAGE}" 2>/dev/null; then
+            docker tag "${GHCR_IMAGE}" "${IMAGE}"
+            echo "Successfully pulled from GHCR mirror"
+            exit 0
+          fi
+          echo "GHCR pull attempt ${attempt} failed, trying upstream..."
+          if docker pull "${IMAGE}"; then
+            echo "Successfully pulled from upstream"
+            exit 0
+          fi
+          echo "Upstream pull attempt ${attempt} failed, retrying in 15s..."
+          sleep 15
+        done
+        echo "WARNING: All pull attempts failed, build script will retry"
 
     - name: 'Fetch build script'
       run: |

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -86,32 +86,42 @@ jobs:
 
     - name: 'Pre-pull dockcross image'
       run: |
+        # Resolve the image tag dynamically from the ITKPythonPackage build scripts
+        # so it matches exactly what the build step will pull.
+        IPP_TAG=${{ inputs.itk-python-package-tag }}
+        IPP_TAG=${IPP_TAG:=main}
+        IPP_ORG=${{ inputs.itk-python-package-org }}
+        IPP_ORG=${IPP_ORG:=InsightSoftwareConsortium}
+
         MANYLINUX_PLATFORM=${{ matrix.manylinux-platform }}
-        MANYLINUX_VERSION=$(echo ${MANYLINUX_PLATFORM} | cut -d '-' -f 1)
-        TARGET_ARCH=$(echo ${MANYLINUX_PLATFORM} | cut -d '-' -f 2)
-        if [[ ${MANYLINUX_VERSION} == _2_28 && ${TARGET_ARCH} == x64 ]]; then
-          IMAGE_TAG="20240304-9e57d2b"
-        elif [[ ${MANYLINUX_VERSION} == 2014 ]]; then
-          IMAGE_TAG="20240304-9e57d2b"
-        else
-          echo "Unknown manylinux platform ${MANYLINUX_PLATFORM}, skipping pre-pull"
+        export MANYLINUX_VERSION=$(echo ${MANYLINUX_PLATFORM} | cut -d '-' -f 1)
+        export TARGET_ARCH=$(echo ${MANYLINUX_PLATFORM} | cut -d '-' -f 2)
+
+        VARS_URL="https://raw.githubusercontent.com/${IPP_ORG}/ITKPythonPackage/${IPP_TAG}/scripts/dockcross-manylinux-set-vars.sh"
+        echo "Fetching image tags from ${VARS_URL}"
+        curl -fsSL "${VARS_URL}" -o /tmp/set-vars.sh || { echo "Could not fetch set-vars.sh, skipping pre-pull"; exit 0; }
+        source /tmp/set-vars.sh
+
+        if [[ -z ${CONTAINER_SOURCE} ]]; then
+          echo "Could not determine container source, skipping pre-pull"
           exit 0
         fi
-        IMAGE="dockcross/manylinux${MANYLINUX_VERSION}-${TARGET_ARCH}:${IMAGE_TAG}"
+
+        # Build the GHCR mirror name
         GHCR_IMAGE="ghcr.io/insightsoftwareconsortium/dockcross-manylinux${MANYLINUX_VERSION}-${TARGET_ARCH}:${IMAGE_TAG}"
-        echo "Pre-pulling ${GHCR_IMAGE} (mirror of docker.io/${IMAGE})"
+        echo "Pre-pulling ${GHCR_IMAGE} (mirror of ${CONTAINER_SOURCE})"
         for attempt in 1 2 3; do
           if docker pull "${GHCR_IMAGE}" 2>/dev/null; then
-            docker tag "${GHCR_IMAGE}" "docker.io/${IMAGE}"
+            docker tag "${GHCR_IMAGE}" "${CONTAINER_SOURCE}"
             echo "Successfully pulled from GHCR mirror"
             exit 0
           fi
-          echo "GHCR pull attempt ${attempt} failed, trying Docker Hub..."
-          if docker pull "docker.io/${IMAGE}"; then
-            echo "Successfully pulled from Docker Hub"
+          echo "GHCR pull attempt ${attempt} failed, trying upstream ${CONTAINER_SOURCE}..."
+          if docker pull "${CONTAINER_SOURCE}"; then
+            echo "Successfully pulled from upstream"
             exit 0
           fi
-          echo "Docker Hub pull attempt ${attempt} failed, retrying in 15s..."
+          echo "Upstream pull attempt ${attempt} failed, retrying in 15s..."
           sleep 15
         done
         echo "WARNING: All pull attempts failed, build script will retry"
@@ -214,18 +224,35 @@ jobs:
 
     - name: 'Pre-pull manylinux aarch64 image'
       run: |
-        IMAGE_TAG="2024-03-25-9206bd9"
-        IMAGE="quay.io/pypa/manylinux_2_28_aarch64:${IMAGE_TAG}"
+        # Resolve the image tag dynamically from the ITKPythonPackage build scripts
+        IPP_TAG=${{ inputs.itk-python-package-tag }}
+        IPP_TAG=${IPP_TAG:=main}
+        IPP_ORG=${{ inputs.itk-python-package-org }}
+        IPP_ORG=${IPP_ORG:=InsightSoftwareConsortium}
+
+        export MANYLINUX_VERSION="_2_28"
+        export TARGET_ARCH="aarch64"
+
+        VARS_URL="https://raw.githubusercontent.com/${IPP_ORG}/ITKPythonPackage/${IPP_TAG}/scripts/dockcross-manylinux-set-vars.sh"
+        echo "Fetching image tags from ${VARS_URL}"
+        curl -fsSL "${VARS_URL}" -o /tmp/set-vars.sh || { echo "Could not fetch set-vars.sh, skipping pre-pull"; exit 0; }
+        source /tmp/set-vars.sh
+
+        if [[ -z ${CONTAINER_SOURCE} ]]; then
+          echo "Could not determine container source, skipping pre-pull"
+          exit 0
+        fi
+
         GHCR_IMAGE="ghcr.io/insightsoftwareconsortium/dockcross-manylinux_2_28-aarch64:${IMAGE_TAG}"
-        echo "Pre-pulling ${GHCR_IMAGE} (mirror of ${IMAGE})"
+        echo "Pre-pulling ${GHCR_IMAGE} (mirror of ${CONTAINER_SOURCE})"
         for attempt in 1 2 3; do
           if docker pull "${GHCR_IMAGE}" 2>/dev/null; then
-            docker tag "${GHCR_IMAGE}" "${IMAGE}"
+            docker tag "${GHCR_IMAGE}" "${CONTAINER_SOURCE}"
             echo "Successfully pulled from GHCR mirror"
             exit 0
           fi
           echo "GHCR pull attempt ${attempt} failed, trying upstream..."
-          if docker pull "${IMAGE}"; then
+          if docker pull "${CONTAINER_SOURCE}"; then
             echo "Successfully pulled from upstream"
             exit 0
           fi

--- a/.github/workflows/mirror-dockcross-images.yml
+++ b/.github/workflows/mirror-dockcross-images.yml
@@ -24,7 +24,10 @@ jobs:
             target: dockcross-manylinux2014-x64:20240304-9e57d2b
           - source: quay.io/pypa/manylinux_2_28_aarch64:2024-03-25-9206bd9
             target: dockcross-manylinux_2_28-aarch64:2024-03-25-9206bd9
-          # v6.0b02 image tags
+          # v6.0b01 image tags
+          - source: docker.io/dockcross/manylinux_2_28-x64:20250913-6ea98ba
+            target: dockcross-manylinux_2_28-x64:20250913-6ea98ba
+          # v6.0b02 / main image tags
           - source: docker.io/dockcross/manylinux_2_28-x64:20260203-3dfb3ff
             target: dockcross-manylinux_2_28-x64:20260203-3dfb3ff
           - source: quay.io/pypa/manylinux_2_28_aarch64:2025.08.12-1

--- a/.github/workflows/mirror-dockcross-images.yml
+++ b/.github/workflows/mirror-dockcross-images.yml
@@ -1,0 +1,46 @@
+name: Mirror dockcross images to GHCR
+
+on:
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+env:
+  GHCR_ORG: ghcr.io/insightsoftwareconsortium
+
+jobs:
+  mirror:
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - source: docker.io/dockcross/manylinux_2_28-x64:20240304-9e57d2b
+            target: dockcross-manylinux_2_28-x64:20240304-9e57d2b
+          - source: docker.io/dockcross/manylinux2014-x64:20240304-9e57d2b
+            target: dockcross-manylinux2014-x64:20240304-9e57d2b
+          - source: quay.io/pypa/manylinux_2_28_aarch64:2024-03-25-9206bd9
+            target: dockcross-manylinux_2_28-aarch64:2024-03-25-9206bd9
+
+    steps:
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Pull source image
+      run: |
+        for attempt in 1 2 3; do
+          docker pull ${{ matrix.source }} && break
+          echo "Pull attempt $attempt failed, retrying in 15s..."
+          sleep 15
+        done
+
+    - name: Tag and push to GHCR
+      run: |
+        docker tag ${{ matrix.source }} ${{ env.GHCR_ORG }}/${{ matrix.target }}
+        docker push ${{ env.GHCR_ORG }}/${{ matrix.target }}

--- a/.github/workflows/mirror-dockcross-images.yml
+++ b/.github/workflows/mirror-dockcross-images.yml
@@ -17,12 +17,18 @@ jobs:
     strategy:
       matrix:
         include:
+          # v5.4.x image tags
           - source: docker.io/dockcross/manylinux_2_28-x64:20240304-9e57d2b
             target: dockcross-manylinux_2_28-x64:20240304-9e57d2b
           - source: docker.io/dockcross/manylinux2014-x64:20240304-9e57d2b
             target: dockcross-manylinux2014-x64:20240304-9e57d2b
           - source: quay.io/pypa/manylinux_2_28_aarch64:2024-03-25-9206bd9
             target: dockcross-manylinux_2_28-aarch64:2024-03-25-9206bd9
+          # v6.0b02 image tags
+          - source: docker.io/dockcross/manylinux_2_28-x64:20260203-3dfb3ff
+            target: dockcross-manylinux_2_28-x64:20260203-3dfb3ff
+          - source: quay.io/pypa/manylinux_2_28_aarch64:2025.08.12-1
+            target: dockcross-manylinux_2_28-aarch64:2025.08.12-1
 
     steps:
     - name: Log in to GHCR


### PR DESCRIPTION
## Summary
- Add a scheduled workflow (`mirror-dockcross-images.yml`) that mirrors all pinned dockcross/manylinux container images to `ghcr.io/insightsoftwareconsortium/`
- Add pre-pull steps with retry logic to the Linux x64 and ARM Python wheel build jobs that dynamically resolve the correct image tag and try the GHCR mirror first

## Problem
Python wheel builds across ~55 remote modules intermittently fail due to transient Docker image pull errors:
- `Error: writing blob: storing blob to file "...": happened during read: unexpected EOF`
- `Error fetching blob: invalid status code from registry 504 (Gateway Timeout)`
- Docker Hub rate limiting (401 Unauthorized / 429 Too Many Requests)

These failures are caused by pulling ~1-2 GB dockcross images from Docker Hub/Quay.io on every CI run using GitHub Actions shared runners.

## How it works

### Dynamic image tag resolution
The pre-pull steps fetch `dockcross-manylinux-set-vars.sh` from the **same ITKPythonPackage version** the build will use (via the `itk-python-package-tag` input). This ensures the pre-pull caches exactly the image the build script needs, regardless of which ITKPythonPackage version the module targets.

### Pre-pull with GHCR mirror + fallback
1. Resolve `IMAGE_TAG` and `CONTAINER_SOURCE` from the ITKPythonPackage build scripts
2. Try pulling from the GHCR mirror (`ghcr.io/insightsoftwareconsortium/dockcross-*`) — same network as GitHub Actions, fast + reliable
3. Fall back to the original Docker Hub / Quay.io source with retry
4. Tag the pulled image with the original name so downstream scripts find it cached
5. Gracefully warn if all attempts fail (build script will retry on its own)

### Edge cases
- **Custom `itk-python-package-tag` refs** (e.g., `release-5.4`): works — `set-vars.sh` exists on that branch with the correct tags
- **Experimental branches** (e.g., `python_based_build_scripts`): graceful skip — no `set-vars.sh` on that branch, pre-pull exits cleanly
- **CXX-only modules**: not affected (no Python build jobs)

### Images mirrored (6 total, covering v5.4.x, v6.0b01, v6.0b02/main)

| Source | GHCR Mirror | Used by |
|--------|-------------|---------|
| `docker.io/dockcross/manylinux_2_28-x64:20240304-9e57d2b` | `ghcr.io/.../dockcross-manylinux_2_28-x64:20240304-9e57d2b` | v5.4.0–v5.4.5 |
| `docker.io/dockcross/manylinux_2_28-x64:20250913-6ea98ba` | `ghcr.io/.../dockcross-manylinux_2_28-x64:20250913-6ea98ba` | v6.0b01 |
| `docker.io/dockcross/manylinux_2_28-x64:20260203-3dfb3ff` | `ghcr.io/.../dockcross-manylinux_2_28-x64:20260203-3dfb3ff` | v6.0b02, main |
| `docker.io/dockcross/manylinux2014-x64:20240304-9e57d2b` | `ghcr.io/.../dockcross-manylinux2014-x64:20240304-9e57d2b` | all versions |
| `quay.io/pypa/manylinux_2_28_aarch64:2024-03-25-9206bd9` | `ghcr.io/.../dockcross-manylinux_2_28-aarch64:2024-03-25-9206bd9` | v5.4.0–v5.4.5 |
| `quay.io/pypa/manylinux_2_28_aarch64:2025.08.12-1` | `ghcr.io/.../dockcross-manylinux_2_28-aarch64:2025.08.12-1` | v6.0b01, v6.0b02, main |

## Testing

Tested across 9 remote modules by pointing their `python-build-workflow` at `@ghcr-mirror-dockcross-images`. See [test results comment](https://github.com/InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/pull/124#issuecomment-4177213405).

**Pre-pull fallback path verified** (GHCR miss → Docker Hub/Quay.io):
- SkullStrip, SimpleITKFilters, TubeTK, IsotropicWavelets: all Python builds pass
- PrincipalComponentsAnalysis: 1 ARM transient EOF on the un-cached image (exactly the failure this PR prevents once GHCR is populated)

**GHCR pull path verified** (5 of 6 images already populated):
- `20240304-9e57d2b` (x64), `20260203-3dfb3ff` (x64), `20240304-9e57d2b` (2014), `2024-03-25-9206bd9` (aarch64), `2025.08.12-1` (aarch64) — all in GHCR
- `20250913-6ea98ba` (x64, v6.0b01) — pending push

## Post-merge steps
- [ ] Trigger the `Mirror dockcross images to GHCR` workflow to populate any missing images
- [ ] Clean up 9 WIP test PRs across remote modules
- [ ] Tag a new release if needed for modules pinned to version tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)