### PR TITLE
ENH: Add platform-specific package install inputs and OS selection

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -30,6 +30,23 @@ on:
         # example: MeshToPolyData@3ad8f08:BSplineGradient@0.3.0
         required: false
         type: string
+      apt-packages:
+        description: 'Space-separated list of apt packages to install on Linux runners before building (e.g. libopenslide-dev libfftw3-dev)'
+        required: false
+        type: string
+      brew-packages:
+        description: 'Space-separated list of Homebrew packages to install on macOS runners before building (e.g. openslide libomp)'
+        required: false
+        type: string
+      choco-packages:
+        description: 'Space-separated list of Chocolatey packages to install on Windows runners before building'
+        required: false
+        type: string
+      os-list:
+        description: 'JSON-formatted array of runner OS labels to build on (default: all platforms)'
+        required: false
+        type: string
+        default: '["ubuntu-22.04", "windows-2022", "macos-15-intel", "macos-15"]'
 
 jobs:
   build-test-cxx:
@@ -37,7 +54,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-15-intel, macos-15]
+        os: ${{ fromJSON(inputs.os-list) }}
         include:
           - os: ubuntu-22.04
             c-compiler: "gcc"
@@ -64,6 +81,22 @@ jobs:
       uses: jlumbroso/free-disk-space@v1.3.1
       with:
         large-packages: false
+
+    - name: Install system packages (Linux)
+      if: inputs.apt-packages != '' && runner.os == 'Linux'
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq ${{ inputs.apt-packages }}
+
+    - name: Install system packages (macOS)
+      if: inputs.brew-packages != '' && runner.os == 'macOS'
+      run: |
+        brew install ${{ inputs.brew-packages }}
+
+    - name: Install system packages (Windows)
+      if: inputs.choco-packages != '' && runner.os == 'Windows'
+      run: |
+        choco install -y ${{ inputs.choco-packages }}
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -87,12 +87,30 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@main
-    with:
-      itk-cmake-options: '-DITK_BUILD_DEFAULT_MODULES:BOOL=OFF -DITKGroup_Core:BOOL=ON'
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@main
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
+    secrets:
+      pypi_password: ${{ secrets.pypi_password }}
+```
+
+#### Modules with external system dependencies
+
+Modules that require system libraries not available on standard runners can use
+the `apt-packages`, `brew-packages`, `choco-packages`, and `os-list` inputs:
+
+```yaml
+jobs:
+  cxx-build-workflow:
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
+    with:
+      apt-packages: 'libopenslide-dev'
+      brew-packages: 'openslide'
+      os-list: '["ubuntu-22.04", "macos-15-intel", "macos-15"]'
+
+  python-build-workflow:
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
     secrets:
       pypi_password: ${{ secrets.pypi_password }}
 ```


### PR DESCRIPTION
## Summary

Add four optional inputs to the CXX build reusable workflow so that remote
modules with external system-library or platform dependencies can keep using
the standard reusable workflow instead of rolling their own:

- `apt-packages` — system packages installed via `apt-get` on Linux runners
- `brew-packages` — system packages installed via `brew` on macOS runners
- `choco-packages` — system packages installed via `choco` on Windows runners
- `os-list` — JSON array of runner OS labels to build on (lets modules
  disable platforms that can't work, e.g., macOS for a CUDA module)

## Motivation

Modules like [ITKIOOpenSlide](https://github.com/InsightSoftwareConsortium/ITKIOOpenSlide)
require system libraries (e.g., `libopenslide-dev`) that are not available
on standard GitHub Actions runners. Previously, these modules had to either:

- Disable CI entirely (IOOpenSlide PR #37)
- Write a completely custom build workflow

With this change, they can simply pass
`apt-packages: 'libopenslide-dev'` (plus the matching `brew-packages` /
`choco-packages` where applicable) to the reusable workflow.

## Usage

```yaml
jobs:
  cxx-build-workflow:
    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
    with:
      apt-packages: 'libopenslide-dev'
      brew-packages: 'openslide'
      os-list: '["ubuntu-22.04", "macos-15-intel", "macos-15"]'
```

Multiple packages can be space-separated:
`apt-packages: 'libopenslide-dev libfftw3-dev'`.

## Details

- Packages are installed via `sudo apt-get install -y -qq` (Linux),
  `brew install` (macOS), or `choco install -y` (Windows)
- The install step is skipped on runners that don't match the input's
  platform (e.g., `apt-packages` is a no-op on macOS/Windows)
- The step is skipped entirely when the corresponding input is not
  provided — no impact on existing modules
- README's short "Example Usage" block now documents the explicit
  `secrets: pypi_password: ${{ secrets.pypi_password }}` whitelist
  form, matching the detailed breakdown later in the same README and
  following the principle of least privilege rather than
  `secrets: inherit`

## Test plan
- [ ] Update ITKIOOpenSlide PR #37 to use `apt-packages: 'libopenslide-dev'` and re-enable the CXX build

🤖 Generated with [Claude Code](https://claude.com/claude-code)