### PR TITLE
COMP: Drop Python 3.9 from default wheel build targets

### DIFF
--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -37,7 +37,7 @@ on:
         type: string
         # Do not build explicit python 3.12 packages. The 3.11 packages support >= 3.11.
         # Python 3.12 and 3.13 aim to maintain ABI compatibility with Python 3.11 through the Stable ABI.
-        default: '["9","10","11"]'
+        default: '["10","11"]'
       manylinux-platforms:
         description: 'JSON-formatted array of "<manylinux-image>-<arch>" specializations'
         required: false


### PR DESCRIPTION
Drop Python 3.9 from the default `python3-minor-versions` on the v6.0b01 branch, matching what main already has.

Most ITK 5.4+ remote module wheels declare `requires-python >= "3.10"` in pyproject.toml. The `test-linux-notebooks` job picks `python3-minor-versions[0]` as its Python — with the old default `["9","10","11"]`, that's Python 3.9, which can't install `>=3.10` wheels.

<details>
<summary>Affected modules</summary>

Any module referencing `@v6.0b01` with `test-notebooks: true` fails:

- InsightSoftwareConsortium/ITKSplitComponents#91
- InsightSoftwareConsortium/ITKMontage#242

Error:
```
ERROR: Package 'itk-splitcomponents' requires a different Python: 3.9.25 not in '>=3.10'
```

</details>

<!--
provenance: claude-code session 2026-04-12
related_prs: ITKSplitComponents#91 ITKMontage#242
-->