### PR TITLE
ENH: Cherry-pick curl retry and platform-specific install from v5.4.6

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -30,6 +30,23 @@ on:
         # example: MeshToPolyData@3ad8f08:BSplineGradient@0.3.0
         required: false
         type: string
+      apt-packages:
+        description: 'Space-separated list of apt packages to install on Linux runners before building (e.g. libopenslide-dev libfftw3-dev)'
+        required: false
+        type: string
+      brew-packages:
+        description: 'Space-separated list of Homebrew packages to install on macOS runners before building (e.g. openslide libomp)'
+        required: false
+        type: string
+      choco-packages:
+        description: 'Space-separated list of Chocolatey packages to install on Windows runners before building'
+        required: false
+        type: string
+      os-list:
+        description: 'JSON-formatted array of runner OS labels to build on (default: all platforms)'
+        required: false
+        type: string
+        default: '["ubuntu-22.04", "windows-2022", "macos-15-intel", "macos-15"]'
 
 jobs:
   build-test-cxx:
@@ -37,7 +54,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-15-intel, macos-15]
+        os: ${{ fromJSON(inputs.os-list) }}
         include:
           - os: ubuntu-22.04
             c-compiler: "gcc"
@@ -64,6 +81,22 @@ jobs:
       uses: jlumbroso/free-disk-space@v1.3.1
       with:
         large-packages: false
+
+    - name: Install system packages (Linux)
+      if: inputs.apt-packages != '' && runner.os == 'Linux'
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq ${{ inputs.apt-packages }}
+
+    - name: Install system packages (macOS)
+      if: inputs.brew-packages != '' && runner.os == 'macOS'
+      run: |
+        brew install ${{ inputs.brew-packages }}
+
+    - name: Install system packages (Windows)
+      if: inputs.choco-packages != '' && runner.os == 'Windows'
+      run: |
+        choco install -y ${{ inputs.choco-packages }}
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v5

--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -146,7 +146,7 @@ jobs:
 
     - name: Fetch CTest driver script
       run: |
-        curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
+        curl --retry 3 --retry-delay 30 --retry-all-errors -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
 
     - name: Configure CTest script
       shell: bash

--- a/.github/workflows/build-test-package-python.yml
+++ b/.github/workflows/build-test-package-python.yml
@@ -99,7 +99,7 @@ jobs:
 
         VARS_URL="https://raw.githubusercontent.com/${IPP_ORG}/ITKPythonPackage/${IPP_TAG}/scripts/dockcross-manylinux-set-vars.sh"
         echo "Fetching image tags from ${VARS_URL}"
-        curl -fsSL "${VARS_URL}" -o /tmp/set-vars.sh || { echo "Could not fetch set-vars.sh, skipping pre-pull"; exit 0; }
+        curl --retry 3 --retry-delay 30 --retry-all-errors -fsSL "${VARS_URL}" -o /tmp/set-vars.sh || { echo "Could not fetch set-vars.sh, skipping pre-pull"; exit 0; }
         source /tmp/set-vars.sh
 
         if [[ -z ${CONTAINER_SOURCE} ]]; then
@@ -132,7 +132,7 @@ jobs:
         IPP_DOWNLOAD_GIT_TAG=${IPP_DOWNLOAD_GIT_TAG:=main}
         IPP_DOWNLOAD_ORG=${{ inputs.itk-python-package-org }}
         IPP_DOWNLOAD_ORG=${IPP_DOWNLOAD_ORG:=InsightSoftwareConsortium}
-        curl -L https://raw.githubusercontent.com/${IPP_DOWNLOAD_ORG}/ITKPythonPackage/${IPP_DOWNLOAD_GIT_TAG}/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O
+        curl --retry 3 --retry-delay 30 --retry-all-errors -L https://raw.githubusercontent.com/${IPP_DOWNLOAD_ORG}/ITKPythonPackage/${IPP_DOWNLOAD_GIT_TAG}/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O
         chmod u+x dockcross-manylinux-download-cache-and-build-module-wheels.sh
 
     - name: 'Build 🐍 Python 📦 package'
@@ -235,7 +235,7 @@ jobs:
 
         VARS_URL="https://raw.githubusercontent.com/${IPP_ORG}/ITKPythonPackage/${IPP_TAG}/scripts/dockcross-manylinux-set-vars.sh"
         echo "Fetching image tags from ${VARS_URL}"
-        curl -fsSL "${VARS_URL}" -o /tmp/set-vars.sh || { echo "Could not fetch set-vars.sh, skipping pre-pull"; exit 0; }
+        curl --retry 3 --retry-delay 30 --retry-all-errors -fsSL "${VARS_URL}" -o /tmp/set-vars.sh || { echo "Could not fetch set-vars.sh, skipping pre-pull"; exit 0; }
         source /tmp/set-vars.sh
 
         if [[ -z ${CONTAINER_SOURCE} ]]; then
@@ -267,7 +267,7 @@ jobs:
         IPP_DOWNLOAD_GIT_TAG=${IPP_DOWNLOAD_GIT_TAG:=main}
         IPP_DOWNLOAD_ORG=${{ inputs.itk-python-package-org }}
         IPP_DOWNLOAD_ORG=${IPP_DOWNLOAD_ORG:=InsightSoftwareConsortium}
-        curl -L https://raw.githubusercontent.com/${IPP_DOWNLOAD_ORG}/ITKPythonPackage/${IPP_DOWNLOAD_GIT_TAG}/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O
+        curl --retry 3 --retry-delay 30 --retry-all-errors -L https://raw.githubusercontent.com/${IPP_DOWNLOAD_ORG}/ITKPythonPackage/${IPP_DOWNLOAD_GIT_TAG}/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O
         chmod u+x dockcross-manylinux-download-cache-and-build-module-wheels.sh
 
     - name: 'Build 🐍 Python 📦 package'
@@ -355,7 +355,7 @@ jobs:
         IPP_DOWNLOAD_GIT_TAG=${IPP_DOWNLOAD_GIT_TAG:=main}
         IPP_DOWNLOAD_ORG=${{ inputs.itk-python-package-org }}
         IPP_DOWNLOAD_ORG=${IPP_DOWNLOAD_ORG:=InsightSoftwareConsortium}
-        curl -L https://raw.githubusercontent.com/${IPP_DOWNLOAD_ORG}/ITKPythonPackage/${IPP_DOWNLOAD_GIT_TAG}/scripts/macpython-download-cache-and-build-module-wheels.sh -O
+        curl --retry 3 --retry-delay 30 --retry-all-errors -L https://raw.githubusercontent.com/${IPP_DOWNLOAD_ORG}/ITKPythonPackage/${IPP_DOWNLOAD_GIT_TAG}/scripts/macpython-download-cache-and-build-module-wheels.sh -O
         chmod u+x macpython-download-cache-and-build-module-wheels.sh
 
     - name: 'Build 🐍 Python 📦 package'

--- a/README.md
+++ b/README.md
@@ -87,12 +87,30 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@main
-    with:
-      itk-cmake-options: '-DITK_BUILD_DEFAULT_MODULES:BOOL=OFF -DITKGroup_Core:BOOL=ON'
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@main
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
+    secrets:
+      pypi_password: ${{ secrets.pypi_password }}
+```
+
+#### Modules with external system dependencies
+
+Modules that require system libraries not available on standard runners can use
+the `apt-packages`, `brew-packages`, `choco-packages`, and `os-list` inputs:
+
+```yaml
+jobs:
+  cxx-build-workflow:
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
+    with:
+      apt-packages: 'libopenslide-dev'
+      brew-packages: 'openslide'
+      os-list: '["ubuntu-22.04", "macos-15-intel", "macos-15"]'
+
+  python-build-workflow:
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
     secrets:
       pypi_password: ${{ secrets.pypi_password }}
 ```


### PR DESCRIPTION
Cherry-pick two commits from `v5.4.6` branch that are general improvements applicable to `main`.

- `9669cfe` **COMP:** Add retry logic to all curl downloads for transient failures
- `7beece0` **ENH:** Add platform-specific package install inputs and OS selection

<details>
<summary>Context</summary>

These were developed on `v5.4.6` but are not version-specific — they improve reliability (curl retries) and flexibility (platform-specific apt/brew package install inputs) for all branches.

A third commit on `v5.4.6` (`6f12423` — default to ITK v5.4.5 wheels) was intentionally excluded as it is v5.4.x-specific.

</details>

<!--
provenance: claude-code session 2026-04-13
key_facts: branch comparison showed v5.4.6 was 3 commits ahead of main; 2 of 3 are general improvements
post_merge_action: side-port main (including these) to v6.0b02 which is 4 commits behind
-->