### PR TITLE
COMP: Add shell: bash to Download ITK step for Windows

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -141,6 +141,7 @@ jobs:
         sudo xcode-select -s "/Applications/Xcode_16.2.0.app"
 
     - name: Download ITK
+      shell: bash
       run: |
         cd "$ITK_BUILD_ROOT"
         git clone https://github.com/InsightSoftwareConsortium/ITK.git


### PR DESCRIPTION
Fix Windows CI failure introduced by #128: the Download ITK step uses `$ITK_BUILD_ROOT` (bash syntax) without specifying `shell: bash`, so on Windows it runs in `pwsh` where the variable is undefined and the `cd` is a no-op.

Same bug exists on `main` — will open a matching PR after this merges.

<details>
<summary>Root cause</summary>

GitHub Actions defaults to `pwsh` on Windows. In PowerShell, environment variables are accessed via `$env:VAR`, not `$VAR`. The "Build ITK (Windows)" step correctly uses `$env:ITK_BUILD_ROOT`, but the "Download ITK" step (which runs on all platforms) uses bash-style `$ITK_BUILD_ROOT` without an explicit `shell: bash` directive.

Result: ITK gets cloned into the repo checkout dir instead of the junction-shortened build root. The subsequent cmake configure fails with `The source directory "D:/PerformanceB/ITK" does not exist`.

</details>

<details>
<summary>Affected modules</summary>

Every module using `@v5.4.6` on Windows is affected. Confirmed failing: ITKPerformanceBenchmarking#98.

</details>

<!--
provenance: claude-code session 2026-04-15
root_cause: #128 changed Download ITK from "cd .." to "cd $ITK_BUILD_ROOT" but didn't add shell: bash
affects: all Windows CI runs using @v5.4.6 after #129 merged
related: ITKPerformanceBenchmarking#98 (confirmed failure)
post_merge_action: open matching PR for main branch
-->