### PR TITLE
COMP: Add shell: bash to Download ITK step for Windows

### DIFF
--- a/.github/workflows/build-test-cxx.yml
+++ b/.github/workflows/build-test-cxx.yml
@@ -141,6 +141,7 @@ jobs:
         sudo xcode-select -s "/Applications/Xcode_16.2.0.app"
 
     - name: Download ITK
+      shell: bash
       run: |
         cd "$ITK_BUILD_ROOT"
         git clone https://github.com/InsightSoftwareConsortium/ITK.git


### PR DESCRIPTION
Backport of #130 to main. Fix Windows CI failure introduced by #128.

The Download ITK step uses `$ITK_BUILD_ROOT` (bash syntax) without `shell: bash`, so on Windows it runs in `pwsh` where the variable is undefined and `cd` is a no-op.

<!--
provenance: claude-code session 2026-04-15
mirrors: #130 (v5.4.6 branch)
-->